### PR TITLE
Added support for function declarations

### DIFF
--- a/contribs/jsdoc2betterjs/examples/sample-class.js
+++ b/contribs/jsdoc2betterjs/examples/sample-class.js
@@ -1,0 +1,11 @@
+var dummy_var = 1;
+
+/**
+ * super bla
+ *
+ * @class
+ * @param  {String} aString - the string
+ */
+function SampleClass(aString){
+	this.length = aString.length;
+}

--- a/contribs/jsdoc2betterjs/examples/sample-function-decl.js
+++ b/contribs/jsdoc2betterjs/examples/sample-function-decl.js
@@ -1,0 +1,11 @@
+var dummy_var = 1;
+
+/**
+ * super bla
+ *
+ * @param  {String} aString - the string measure
+ * @return {Number} the length of the string
+ */
+function stringLength(aString){
+	return aString.length
+}

--- a/contribs/jsdoc2betterjs/libs/jsdocParse.js
+++ b/contribs/jsdoc2betterjs/libs/jsdocParse.js
@@ -215,8 +215,11 @@ jsdocParse.extractJsdocContent	= function(lines, bottomLine){
 	for(var lineStart = lineEnd;lineStart >= 0; lineStart--){
 		var line	= lines[lineStart]
 		var matches	= line.match(/^\s*\/\*\*\s*$/)
-		var isJsdocHead	= matches !== null ? true : false
-		if( isJsdocHead === true )	break
+		if( matches !== null )	break
+
+		// check for other comment markers and abort if found
+		matches = line.match(/\/\*/);
+		if( matches !== null ) return null
 	}
 	if( lineEnd <= lineStart )	return null
 	var jsdocContent	= lines.slice(lineStart, lineEnd+1).join('\n')


### PR DESCRIPTION
Uses the method detailed in the TODO file. Tested on classes and it seems to work.

Also a fix for non-jsdocs comment blocks before a function causing confusion for the parser.
